### PR TITLE
Create post with string id instead of int.

### DIFF
--- a/graphql/database.js
+++ b/graphql/database.js
@@ -8,7 +8,7 @@ import Post from '../data/model/Post';
 const viewerId = 'qoyciemasklfhkel';
 
 export function createPost({creatorId, title, description, image}) {
-  const id = posts.length + 1;
+  const id = '' + posts.length + 1;
   const newPost = new Post({id, creatorId, title, image, description});
   posts.push(newPost);
 


### PR DESCRIPTION
Fixes [#1](https://github.com/jkettmann/relay-authentication/issues/1). Posts were created with integer id instead of a string.
